### PR TITLE
use absolute not relative path for matchpathcon_init_prefix()

### DIFF
--- a/timedatex.c
+++ b/timedatex.c
@@ -711,17 +711,17 @@ error:
 	return g_variant_new_string("");
 }
 
-static void set_default_file_context(const gchar *path, const gchar *target) {
+static void set_localtime_file_context(const gchar *path) {
 #ifdef HAVE_SELINUX
 	security_context_t con;
 
 	if (!is_selinux_enabled())
 		return;
 
-	if (matchpathcon_init_prefix(NULL, target))
+	if (matchpathcon_init_prefix(NULL, LOCALTIME_PATH))
 		return;
 
-	if (!matchpathcon(LOCALTIME_PATH, 0, &con)) {
+	if (!matchpathcon(LOCALTIME_PATH, S_IFLNK, &con)) {
 		lsetfilecon(path, con);
 		freecon(con);
 	}
@@ -791,7 +791,7 @@ static void finish_set_timezone(GDBusMethodInvocation *invocation, struct method
 	if (symlink(link, tmp))
 		goto error;
 
-	set_default_file_context(tmp, link);
+	set_localtime_file_context(tmp);
 
 	if (rename(tmp, LOCALTIME_PATH)) {
 		unlink(tmp);


### PR DESCRIPTION
Fixes RHBZ #1190377. The second argument to `set_default_file_context()` is passed as the second argument to `matchpathcon_init_prefix()` in `set_default_file_context()`. In the existing code, this value will be something like `../usr/share/zoneinfo/America/Vancouver`. `matchpathcon_init_prefix()` is documented thus:

matchpathcon_init_prefix() is the same as matchpathcon_init but only loads entries with regular expressions that have stems prefixed by prefix. 

Thus we're asking libselinux to load only the contexts prefixed with `../usr/share/zoneinfo/whatever`, which will be none of them, because they'll be prefixed with `/usr/share/zoneinfo/whatever`.

My tests indicate that this bug is usually hidden because when `sefcontext_compile` has been run (which will usually be the case - the case we've found where it is _not_ true is right after an install from a live image, before any update to any selinux package), and the compiled .bin files in `/etc/selinux/targeted/contexts/files/` exist, it doesn't matter what prefix you pass to `matchpathcon_init_prefix()`, you actually get all entries loaded. You can call `matchpathcon_init_prefix(NULL, '/foobar')` and subsequent `matchpathcon()` calls for _any_ path will return the correct value. But if `sefcontext_compile` has _not_ been run, `matchpathcon_init_prefix()` actually behaves as described, and you have to get the prefix right.

I've tested, and this definitely fixes RHBZ #1190377 for me. It's fairly easy to reproduce: just install https://dl.fedoraproject.org/pub/alt/stage/22_TC2/Workstation/i386/iso/Fedora-Live-Workstation-i686-22-TC2.iso , don't create a user during install, and change the timezone during the GNOME Initial Setup process and you'll see an SELinux denial when you log in. Or, just install from that ISO, create a user any way you like, and after logging in, change the timezone using the GNOME Control Center; the first time you'll see the AVC notification, and each time you do it you can do `ls -lZ /etc/localtime` to check the context. You can do `restorecon /etc/localtime` to correct it, change the timezone, and see that it breaks again.

If you then try it with this fix applied to timedatex, it works correctly. I did a scratch build - http://koji.fedoraproject.org/koji/taskinfo?taskID=9682170 . I built a live image with that timedatex included, ran through the reproducer scenarios, and could not reproduce the bug, the context is now set correctly.

A simpler fix would be just to call `matchpathcon_init()`, of course. Presumably we use `matchpathcon_init_prefix()` instead as an optimization, for speed or memory consumption - is it really significant? I'm still not entirely sure this code is doing the right thing, because doesn't it ask selinux to load only the context for the _new_ timezone file, then try and check the context for the `/etc/localtime` symlink which at this point will still be pointing to the _old_ timezone file? It definitely works in testing, but it still seems a bit odd.
